### PR TITLE
feat: 시설 위치 기반 검색 API 구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
 	// WebClient를 사용하기 위한 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// 공간 데이터 타입을 사용하기 위한 의존성
+	implementation 'org.hibernate.orm:hibernate-spatial'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/nationalfitnessapp/controller/FacilityController.java
+++ b/src/main/java/com/example/nationalfitnessapp/controller/FacilityController.java
@@ -1,0 +1,80 @@
+package com.example.nationalfitnessapp.controller;
+
+import com.example.nationalfitnessapp.service.FacilityService;
+import com.example.nationalfitnessapp.dto.FacilityResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/facilities")
+@RequiredArgsConstructor
+public class FacilityController {
+
+    private final FacilityService facilityService;
+
+    /**
+     * 지도에 표시할 시설 목록을 조회하는 API
+     * @param lon 지도 중심의 경도
+     * @param lat 지도 중심의 위도
+     * @param radius 검색 반경 (meter), 기본값 3000m
+     * @return 시설 목록
+     * */
+    @GetMapping("/map")
+    public List<FacilityResponseDto> getFacilitiesForMap(
+            @RequestParam double lon,
+            @RequestParam double lat,
+            @RequestParam(defaultValue = "3000") int radius
+    ) {
+        return facilityService.findFacilitiesWithinRadius(lon, lat, radius);
+    }
+
+    /**
+     * 현재 위치에서 가까운 순서대로 시설 목록을 조회하는 API (페이징)
+     * @param lon 현재 위치의 경도
+     * @param lat 현재 위치의 위도
+     * @param page 요청할 페이지 번호 (0부터 시작)
+     * @param size 한 페이지에 보여줄 데이터 개수 (기본값 10)
+     * @return 페이징된 시설 목록
+     * */
+    @GetMapping("/list")
+    public Page<FacilityResponseDto> getFacilitiesForList(
+            @RequestParam double lon,
+            @RequestParam double lat,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return facilityService.findFacilitiesSortedByDistance(lon, lat, pageable);
+    }
+
+    /**
+     * 시설을 이름 또는 카테고리로 검색하는 API
+     * @param lat 현재 위치의 위도
+     * @param lon 현재 위치의 경도
+     * @param name (선택) 검색할 시설 이름 키워드
+     * @param categoryName (선택) 조건 검색에 활용할 카테고리명
+     * @param page (선택) 요청할 페이지 번호 (0부터 시작)
+     * @param size 한 페이지에 보여줄 데이터 개수 (기본값 10)
+     * @return 페이징된 시설 목록
+     * */
+    @GetMapping("/search")
+    public Page<FacilityResponseDto> searchFacilities(
+            @RequestParam Double lat,
+            @RequestParam Double lon,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String categoryName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return facilityService.searchFacilities(lat, lon, name, categoryName, pageable);
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/domain/Facility.java
+++ b/src/main/java/com/example/nationalfitnessapp/domain/Facility.java
@@ -1,9 +1,8 @@
 package com.example.nationalfitnessapp.domain;
 import jakarta.persistence.*;
-
 import lombok.*;
-
 import java.time.LocalDateTime;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Table(name = "Facility")
@@ -52,4 +51,7 @@ public class Facility {
 
     @Column
     private String isNation;
+
+    @Column(columnDefinition = "POINT SRID 4326")
+    private Point location;
 }

--- a/src/main/java/com/example/nationalfitnessapp/dto/FacilityResponseDto.java
+++ b/src/main/java/com/example/nationalfitnessapp/dto/FacilityResponseDto.java
@@ -1,0 +1,50 @@
+package com.example.nationalfitnessapp.dto;
+
+import com.example.nationalfitnessapp.domain.Facility;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FacilityResponseDto {
+
+    private final Long facilityId;
+    private final String name;
+    private final String groupName;
+    private final String typeName;
+    private final String categoryName;
+    private final String status;
+    private final String postalCode;
+    private final String roadAddress;
+    private final Double latitude;
+    private final Double longitude;
+    private final String phoneNumber;
+    private final LocalDateTime lastUpdateDate;
+    private final String isNation;
+    private final Double distance;
+
+    public FacilityResponseDto(Facility facility, Double distance) {
+        this.facilityId = facility.getFacilityId();
+        this.name = facility.getName();
+        this.groupName = facility.getGroupName();
+        this.typeName = facility.getTypeName();
+        this.categoryName = facility.getCategoryName();
+        this.status = facility.getStatus();
+        this.postalCode = facility.getPostalCode();
+        this.roadAddress = facility.getRoadAddress();
+        this.phoneNumber = facility.getPhoneNumber();
+        this.lastUpdateDate = facility.getLastUpdateDate();
+        this.isNation = facility.getIsNation();
+
+        // Entity의 Point 객체에서 위도(Y), 경도(X) 값을 추출하여 DTO 필드에 할당합니다.
+        // 이 과정을 통해 JSON 변환 시 무한 루프 에러를 방지합니다.
+        if (facility.getLocation() != null) {
+            this.latitude = facility.getLocation().getY();
+            this.longitude = facility.getLocation().getX();
+        } else {
+            this.latitude = null;
+            this.longitude = null;
+        }
+        this.distance = distance;
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepository.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepository.java
@@ -22,19 +22,15 @@ public interface FacilityRepository extends JpaRepository<Facility, Long>, JpaSp
     * */
     boolean existsByRoadAddress(String roadAddress);
 
-    // [수정] 반환 타입을 간단하게 Page<Facility>로 변경
     @Query(value = "SELECT * FROM facility f " +
             "ORDER BY ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326))",
             countQuery = "SELECT count(*) FROM facility",
             nativeQuery = true)
     Page<Facility> findFacilitiesOrderByDistance(@Param("point") String point, Pageable pageable);
 
-    // [수정] 지도 API도 간단하게 List<Facility>를 반환하도록 변경
     @Query(value = "SELECT * FROM facility f " +
             "WHERE ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326)) <= :radius " +
             "ORDER BY ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326))",
             nativeQuery = true)
     List<Facility> findFacilitiesWithinRadius(@Param("point") String point, @Param("radius") int radius);
-
-    //
 }

--- a/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepository.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepository.java
@@ -1,10 +1,16 @@
 package com.example.nationalfitnessapp.repository;
 
 import com.example.nationalfitnessapp.domain.Facility;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 // JpaRepository를 상속받고, 제네릭으로 <관리할 엔티티, 엔티티 ID 타입>을 지정한다.
-public interface FacilityRepository extends JpaRepository<Facility, Long>{
+public interface FacilityRepository extends JpaRepository<Facility, Long>, JpaSpecificationExecutor<Facility>, FaciltiyRepositoryCustom{
 
     /*
     * 데이터 중복 방지 메서드
@@ -15,4 +21,20 @@ public interface FacilityRepository extends JpaRepository<Facility, Long>{
     * Service 클래스에서 이 함수를 사용해 중복이 아닌 데이터만 통과시키는 방식으로 사용한다.
     * */
     boolean existsByRoadAddress(String roadAddress);
+
+    // [수정] 반환 타입을 간단하게 Page<Facility>로 변경
+    @Query(value = "SELECT * FROM facility f " +
+            "ORDER BY ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326))",
+            countQuery = "SELECT count(*) FROM facility",
+            nativeQuery = true)
+    Page<Facility> findFacilitiesOrderByDistance(@Param("point") String point, Pageable pageable);
+
+    // [수정] 지도 API도 간단하게 List<Facility>를 반환하도록 변경
+    @Query(value = "SELECT * FROM facility f " +
+            "WHERE ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326)) <= :radius " +
+            "ORDER BY ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326))",
+            nativeQuery = true)
+    List<Facility> findFacilitiesWithinRadius(@Param("point") String point, @Param("radius") int radius);
+
+    //
 }

--- a/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepositoryImpl.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/FacilityRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.example.nationalfitnessapp.repository;
+
+import com.example.nationalfitnessapp.domain.Facility;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FacilityRepositoryImpl implements FaciltiyRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Page<Facility> searchWithDistance(Double latitude, Double longitude, String name, String categoryName, Pageable pageable) {
+
+        // 1. 네이티브 SQL 쿼리 생성을 위한 StringBuilder
+        StringBuilder sql = new StringBuilder("SELECT f.* FROM facility f WHERE 1=1");
+        Map<String, Object> parameters = new HashMap<>();
+
+        // 2. 조건이 있을 경우 WHERE 절 추가
+        if (name != null && !name.isEmpty()) {
+            sql.append(" AND f.name LIKE :name");
+            parameters.put("name", "%" + name + "%");
+        }
+        if (categoryName != null && !categoryName.isEmpty()) {
+            if ("기타".equals(categoryName)) {
+                List<String> mainCategories = List.of("축구장", "야구장", "체육관", "수영장", "풋살장", "종합체육시설");
+                sql.append(" AND f.category_name NOT IN :mainCategories");
+                parameters.put("mainCategories", mainCategories);
+            } else {
+                sql.append(" AND f.category_name = :categoryName");
+                parameters.put("categoryName", categoryName);
+            }
+        }
+
+        // 3. 거리순 정렬이 필요한 경우 ORDER BY 절 추가
+        if (latitude != null && longitude != null) {
+            String pointWKT = String.format("POINT(%f %f)", latitude, longitude);
+            sql.append(" ORDER BY ST_DISTANCE_SPHERE(f.location, ST_PointFromText(:point, 4326))");
+            parameters.put("point", pointWKT);
+        } else if (pageable.getSort().isSorted()) {
+            // JPQL의 Sort.toString()은 네이티브 쿼리와 호환되지 않을 수 있어 직접 처리
+            // 예시: 이름순 기본 정렬
+            sql.append(" ORDER BY f.name ASC");
+        }
+
+        // 4. 네이티브 쿼리 생성 및 파라미터 바인딩
+        // createNativeQuery의 두 번째 인자로 결과를 매핑할 엔티티 클래스를 지정
+        Query query = entityManager.createNativeQuery(sql.toString(), Facility.class);
+        for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
+        }
+
+        // 5. 페이징 처리
+        query.setFirstResult((int) pageable.getOffset());
+        query.setMaxResults(pageable.getPageSize());
+
+        List<Facility> facilities = query.getResultList();
+
+        // 6. 전체 카운트를 위한 쿼리 실행
+        long total = countFacilities(name, categoryName);
+
+        return new PageImpl<>(facilities, pageable, total);
+    }
+
+    private long countFacilities(String name, String categoryName) {
+        StringBuilder countSql = new StringBuilder("SELECT count(*) FROM facility f WHERE 1=1");
+        Map<String, Object> countParameters = new HashMap<>();
+
+        if (name != null && !name.isEmpty()) {
+            countSql.append(" AND f.name LIKE :name");
+            countParameters.put("name", "%" + name + "%");
+        }
+        if (categoryName != null && !categoryName.isEmpty()) {
+            if ("기타".equals(categoryName)) {
+                List<String> mainCategories = List.of("축구장", "야구장", "체육관", "수영장", "풋살장", "종합체육시설");
+                countSql.append(" AND f.category_name NOT IN :mainCategories");
+                countParameters.put("mainCategories", mainCategories);
+            } else {
+                countSql.append(" AND f.category_name = :categoryName");
+                countParameters.put("categoryName", categoryName);
+            }
+        }
+
+        Query countQuery = entityManager.createNativeQuery(countSql.toString());
+        for (Map.Entry<String, Object> entry : countParameters.entrySet()) {
+            countQuery.setParameter(entry.getKey(), entry.getValue());
+        }
+
+        // 네이티브 카운트 쿼리는 BigInteger 또는 Long으로 반환될 수 있음
+        return ((Number) countQuery.getSingleResult()).longValue();
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/repository/FacilitySpecification.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/FacilitySpecification.java
@@ -1,0 +1,42 @@
+package com.example.nationalfitnessapp.repository;
+
+import com.example.nationalfitnessapp.domain.Facility;
+import org.springframework.data.jpa.domain.Specification;
+import java.util.Arrays;
+import java.util.List;
+
+public class FacilitySpecification {
+
+    public static Specification<Facility> Empty() { return (root, query, criteriaBuilder) -> null; }
+
+    /**
+     * 이름(name)에 특정 키워드가 포함되는 조건을 생성한다. (like 검색)
+     * @param name 검색할 키워드
+     * @return 이름 검색 조건(Specification)
+     * */
+    public static Specification<Facility> likeName(String name) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("name"), "%" + name + "%");
+    }
+
+    /**
+     * 카테고리(categoryName)로 검색하는 조건을 생성
+     * "기타"를 검색하면 주요 6개 카테고리를 제외한 나머지를 검색한다.
+     * @param categoryName 검색할 카테고리명
+     * @return 카테고리 검색 조건(Specification)
+     * */
+    public static Specification<Facility> filterByCategoryName(String categoryName){
+        // 주요 6개 카테고리 목록
+        List<String> mainCategories = Arrays.asList("축구장", "야구장", "체육관", "수영장", "풋살장", "종합체육시설");
+
+        return (root, query, criteriaBuilder) -> {
+            if ("기타".equals(categoryName)) {
+                // '기타'인 경우: 주요 카테고리 목록에 포함되지 않는 (NOT INT) 데이터 검색
+                return criteriaBuilder.not(root.get("categoryName").in(mainCategories));
+            } else {
+                return criteriaBuilder.equal(root.get("categoryName"), categoryName);
+            }
+        };
+    }
+
+
+}

--- a/src/main/java/com/example/nationalfitnessapp/repository/FaciltiyRepositoryCustom.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/FaciltiyRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.nationalfitnessapp.repository;
+
+import com.example.nationalfitnessapp.domain.Facility;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FaciltiyRepositoryCustom {
+    Page<Facility> searchWithDistance(Double latitude, Double longitude, String name, String categoryName, Pageable pageable);
+}

--- a/src/main/java/com/example/nationalfitnessapp/service/FacilityService.java
+++ b/src/main/java/com/example/nationalfitnessapp/service/FacilityService.java
@@ -1,13 +1,16 @@
 package com.example.nationalfitnessapp.service;
 
 import com.example.nationalfitnessapp.domain.Facility;
-import com.example.nationalfitnessapp.repository.FacilityRepository;
 import com.example.nationalfitnessapp.dto.FacilityApiResponse;
 import com.example.nationalfitnessapp.dto.FacilityDto;
-
+import com.example.nationalfitnessapp.dto.FacilityResponseDto;
+import com.example.nationalfitnessapp.repository.FacilityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,11 +18,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
-@Slf4j  // 로그 출력을 위한 Lombok 어노테이션
-@Service  // 서비스 클래스임을 알리는 어노테이션
-@Transactional(readOnly = true)  // 클래스 전체에 기본적으로 readOnly 작업만 이루어지도록 설정하는 어노테이션
-@RequiredArgsConstructor  // final 필드에 대한 생성자를 자동으로 만들어주는 Lombok 어노테이션
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class FacilityService {
 
     private final FacilityRepository facilityRepository;
@@ -31,64 +35,139 @@ public class FacilityService {
     @Value("${facility.api.baseUrl}")
     private String baseUrl;
 
-    /*
-    * 공공데이터 API를 호출하여 체육 시설 데이터를 DB에 저장하는 메서드
-    * */
+    /**
+     * 공공데이터 API를 호출하여 모든 체육 시설 데이터를 DB에 저장하는 메서드.
+     * 페이징 기법을 사용하여 전체 데이터를 순회합니다.
+     */
     @Transactional
     public void fetchAndSaveFacilities() {
         log.info("체육 시설 데이터 API 호출 및 저장을 시작합니다.");
-        int savedCount = 0;
+        final int TOTAL_COUNT = 146746;
+        final int ROWS_PER_PAGE = 1000;
+        int totalPages = (TOTAL_COUNT + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE;
+        int totalSavedCount = 0;
 
+        log.info("총 데이터: {}, 페이지당 데이터: {}, 총 페이지: {}", TOTAL_COUNT, ROWS_PER_PAGE, totalPages);
 
-        for (int i = 1; i <= 147; i++) {  // 데이터 다운로드 완료
-            // 1. UriComponentsBuilder를 사용해 전체 URL과 파라미터를 먼저 조합
+        for (int page = 1; page <= totalPages; page++) {
+            log.info("시설 데이터 페이지 {}/{} 처리 중...", page, totalPages);
             String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
                     .queryParam("serviceKey", serviceKey)
-                    .queryParam("pageNo", i)
-                    .queryParam("numOfRows", 1000)
+                    .queryParam("pageNo", page)
+                    .queryParam("numOfRows", ROWS_PER_PAGE)
                     .queryParam("resultType", "xml")
-                    .queryParam("cp_nm", "")  // 필수 파라미터는 아니지만, 데이터를 제대로 입력받으려면 최소한 하나 이상의 검색 조건 파라미터가 있어야 한다.
                     .build(true)
                     .toUriString();
 
-            // 2. 완성된 URL을 uri 메서드에 직접 전달
             FacilityApiResponse facilityApiResponse = webClient.get()
                     .uri(url)
                     .retrieve()
                     .bodyToMono(FacilityApiResponse.class)
                     .block();
 
-            // 3. 응답 데이터에서 실제 시설 목록(List<FacilityDto>) 추출
             List<FacilityDto> dtoList = extractFacilityDtos(facilityApiResponse);
             if (dtoList.isEmpty()) {
-                log.warn("API로부터 유효한 시설 데이터를 받아오지 못했거나, 모든 데이터가 이미 존재합니다.");
+                log.warn("페이지 {}에서 유효한 데이터를 받아오지 못했습니다.", page);
                 continue;
             }
 
-            // 4. DTO 리스트를 순회하며 Entity로 변환 후 저장
+            int savedCountInPage = 0;
             for (FacilityDto dto : dtoList) {
                 if (dto.getRoadAddress() != null && !dto.getRoadAddress().isEmpty()) {
                     if (!facilityRepository.existsByRoadAddress(dto.getRoadAddress())) {
                         Facility facility = dto.toEntity();
                         facilityRepository.save(facility);
-                        savedCount++;
+                        savedCountInPage++;
                     }
                 }
             }
+            totalSavedCount += savedCountInPage;
         }
-        log.info("총 {}개의 새로운 시설 데이터 저장을 완료했습니다.", savedCount);
+        log.info("총 {}개의 새로운 시설 데이터 저장을 완료했습니다.", totalSavedCount);
     }
 
-
-
-    // 중첩된 ApiResponse 객체에서 FacilityDto 리스트를 안전하게 추출하는 헬퍼 메서드
     private List<FacilityDto> extractFacilityDtos(FacilityApiResponse facilityApiResponse){
-        if (facilityApiResponse != null &&
-            facilityApiResponse.getBody() != null &&
-            facilityApiResponse.getBody().getItems() != null &&
-            facilityApiResponse.getBody().getItems().getFacilityList() != null) {
+        if (facilityApiResponse != null && facilityApiResponse.getBody() != null && facilityApiResponse.getBody().getItems() != null && facilityApiResponse.getBody().getItems().getFacilityList() != null) {
             return facilityApiResponse.getBody().getItems().getFacilityList();
         }
         return Collections.emptyList();
+    }
+
+    /**
+     * 지도 뷰 기능: 특정 지점 반경 내의 모든 시설을 검색합니다.
+     * @param longitude 중심점의 경도 (X 좌표)
+     * @param latitude  중심점의 위도 (Y 좌표)
+     * @param radius    검색할 반경 (미터 단위)
+     * @return          거리 정보가 포함된 시설 DTO 리스트
+     */
+    public List<FacilityResponseDto> findFacilitiesWithinRadius(double longitude, double latitude, int radius) {
+        String pointWKT = String.format("POINT(%s %s)", latitude, longitude);
+        List<Facility> facilities = facilityRepository.findFacilitiesWithinRadius(pointWKT, radius);
+
+        return facilities.stream()
+                .map(facility -> {
+                    Double distance = calculateDistance(longitude, latitude, facility.getLocation());
+                    return new FacilityResponseDto(facility, distance);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 목록 뷰 기능: 특정 지점에서 가까운 순서대로 시설을 검색합니다 (페이징 적용).
+     * @param longitude 기준점의 경도 (X 좌표)
+     * @param latitude  기준점의 위도 (Y 좌표)
+     * @param pageable  페이징 정보 (페이지 번호, 페이지 크기)
+     * @return          거리 정보가 포함된 페이징된 시설 DTO
+     */
+    public Page<FacilityResponseDto> findFacilitiesSortedByDistance(double longitude, double latitude, Pageable pageable) {
+        String pointWKT = String.format("POINT(%s %s)", latitude, longitude);
+
+        Page<Facility> facilityPage = facilityRepository.findFacilitiesOrderByDistance(pointWKT, pageable);
+
+        return facilityPage.map(facility -> {
+            Double distance = calculateDistance(longitude, latitude, facility.getLocation());
+            return new FacilityResponseDto(facility, distance);
+        });
+    }
+
+    /**
+     * 두 좌표 간의 거리를 미터 단위로 계산하는 헬퍼 메서드
+     * @param lon1      시작점의 경도
+     * @param lat1      시작점의 위도
+     * @param destPoint 도착점의 Point 객체
+     * @return          두 지점 사이의 거리 (미터 단위, 근사치)
+     */
+    private Double calculateDistance(double lon1, double lat1, Point destPoint) {
+        if (destPoint == null) {
+            return null;
+        }
+        // JTS 라이브러리는 좌표를 Degree 단위로 계산하므로, 미터 단위로 변환 (근사치)
+        // 1 degree ≈ 111,195 meters
+        double degreeDistance = Math.sqrt(Math.pow(lon1 - destPoint.getX(), 2) + Math.pow(lat1 - destPoint.getY(), 2));
+        return degreeDistance * 111195;
+    }
+
+    /**
+     * 다양한 조건으로 시설을 검색하고, 거리 정보를 포함하여 반환하는 메서드
+     * @param latitude 기준점의 위도
+     * @param longitude 기준점의 경도
+     * @param name (선택) 검색할 시설 이름 키워드
+     * @param categoryName (선택) 검색할 카테고리명
+     * @param pageable 페이징 정보
+     * @return 페이징된 시설 DTO 목록
+     * */
+    public Page<FacilityResponseDto> searchFacilities(Double latitude, Double longitude, String name, String categoryName, Pageable pageable) {
+
+        // Custom 메서드를 직접 호출
+        Page<Facility> facilityPage = facilityRepository.searchWithDistance(latitude, longitude, name, categoryName, pageable);
+
+        // 결과 DTO 변환
+        return facilityPage.map(facility -> {
+            Double distance = null;
+            if (latitude != null && longitude != null) {
+                distance = calculateDistance(longitude, latitude, facility.getLocation());
+            }
+            return new FacilityResponseDto(facility, distance);
+        });
     }
 }


### PR DESCRIPTION
### 주요 변경 사항
**DB & Entity:**
- Facility 엔티티에 Point 타입의 location 컬럼을 추가하고, 빠른 검색을 위해 **공간 인덱스(Spatial Index)** 설정
- hibernate-spatial 의존성을 추가하여 JPA에서 공간 데이터 타입을 처리할 수 있도록 설정

**Repository:**
- Custom Repository(FacilityRepositoryCustom, FacilityRepositoryImpl)를 구현하여 동적 네이티브 쿼리 로직 추가
- EntityManager를 사용하여 이름, 카테고리 필터링과 거리순 정렬이 동적으로 조합되는 SQL 생성

**DTO:**
- API 응답 전용 DTO인 FacilityResponseDto 생성
- Entity의 Point 객체를 클라이언트가 사용하기 쉬운 latitude, longitude로 변환하고, 계산된 distance 값 포함

**Service:**
- 새로 구현한 Custom Repository를 사용하여 복잡한 검색 조건을 처리하는 searchFacilities 로직 구현
- 조회된 Facility 엔티티를 FacilityResponseDto로 변환하는 로직 추가

**Controller:**
- GET /api/facilities/map: 반경 내 시설 조회를 위한 API 엔드포인트 추가
- GET /api/facilities/list: 거리순으로 페이징된 시설 목록 조회를 위한 API 엔드포인트 추가
- GET /api/facilities/search: 이름, 카테고리 등 다중 필터링을 지원하는 통합 검색 API 엔드포인트 추가

