### PR TITLE
feat: JWT 기반 회원가입 및 로그인 기능 구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	// WebClient를 사용하기 위한 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// 기본 웹 서버 구동용 (MVC)
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	// 공간 데이터 타입을 사용하기 위한 의존성
 	implementation 'org.hibernate.orm:hibernate-spatial'
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,14 @@ dependencies {
 
 	// 공간 데이터 타입을 사용하기 위한 의존성
 	implementation 'org.hibernate.orm:hibernate-spatial'
+
+	// Spring Security 추가 (비밀번호 암호화 등)
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT 라이브러리 추가 (jjwt)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/nationalfitnessapp/config/SecurityConfig.java
+++ b/src/main/java/com/example/nationalfitnessapp/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.example.nationalfitnessapp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/config/SecurityConfig.java
+++ b/src/main/java/com/example/nationalfitnessapp/config/SecurityConfig.java
@@ -4,12 +4,32 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())  // 1. REST API는 세션을 사용하지 않고 JWT 토큰 방식을 사용하므로 CSRF 보호 비활성화
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))  //  2. 세션 비활성화 (JWT 기반 인증에서는 서버가 세션을 유지할 필요가 없음)
+                .authorizeHttpRequests(auth -> auth  // 3. 특정 URL에 대한 접근 권한 설정
+                        .requestMatchers("/api/auth/**").permitAll()  // 3-1. "/api/auth/**" 패턴의 URL 요청은 인증 없이 모두 허용
+                        .requestMatchers("/api/exercises/**").permitAll()  // 3-2. "/api/exercises/**" 패턴의 URL 요청은 인증 없이 모두 허용
+                        .requestMatchers("/api/facilities/**").permitAll()  // 3-3. "/api/facilities/**" 패턴의 URL 요청은 인증 없이 모두 허용
+                        .anyRequest().authenticated()  // 3-4. 그 외의 모든 요청은 반드시 인증을 거쳐야 함
+                );
+
+        return http.build();
     }
 }

--- a/src/main/java/com/example/nationalfitnessapp/controller/AuthController.java
+++ b/src/main/java/com/example/nationalfitnessapp/controller/AuthController.java
@@ -1,0 +1,62 @@
+package com.example.nationalfitnessapp.controller;
+
+import com.example.nationalfitnessapp.domain.User;
+import com.example.nationalfitnessapp.dto.LoginRequestDto;
+import com.example.nationalfitnessapp.dto.SignupRequestDto;
+import com.example.nationalfitnessapp.dto.TokenDto;
+import com.example.nationalfitnessapp.dto.TokenRequestDto;
+import com.example.nationalfitnessapp.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    /**
+     * 회원가입 API
+     * @param requestDto SignupRequestDto 형식으로 저장된 Dto
+     * @return http response와 생성된 User 정보를 보낸다.
+     * */
+    @PostMapping("/signup")
+    public ResponseEntity<User> signup(@RequestBody SignupRequestDto requestDto) {
+        User savedUser = userService.signUp(
+                requestDto.getLoginId(),
+                requestDto.getPassword(),
+                requestDto.getNickname(),
+                requestDto.getEmail()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);  // CREATED라는 http response를 보내고 body에 저장된 user를 보낸다.
+    }
+
+    /**
+     * 로그인 API
+     * @param requestDto LoginRequestDto 형식으로 저장된 Dto
+     * @return http response와 토큰 Dto를 반환한다.
+     * */
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@RequestBody LoginRequestDto requestDto) {
+        TokenDto tokenDto = userService.login(requestDto.getLoginId(), requestDto.getPassword());
+        // 성공 시 Http 200 OK 상태 코드와 함께 DTO 반환
+        return ResponseEntity.ok(tokenDto);
+    }
+
+    /**
+     * 토큰 재발급 API
+     * @param requestDto TokenRequestDto 형식으로 저장된 Dto
+     * @return http response와 토큰 Dto를 반환한다.
+     * */
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenDto> refresh(@RequestBody TokenRequestDto requestDto) {
+        TokenDto newTokenDto = userService.refreshToken(requestDto.getAccessToken(), requestDto.getRefreshToken());
+        return ResponseEntity.ok(newTokenDto);
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/domain/User.java
+++ b/src/main/java/com/example/nationalfitnessapp/domain/User.java
@@ -1,4 +1,5 @@
 package com.example.nationalfitnessapp.domain;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import lombok.AllArgsConstructor;  // 모든 필드를 파라미터로 가지는 생성자 자동 생성
@@ -35,8 +36,17 @@ public class User {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @JsonIgnore
+    @Column(length = 512)
+    private String refreshToken;
+
     @PrePersist  // 엔티티가 생성될 때 이 메서드를 호출한다.
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    // Refresh Token 업데이터를 위한 편의 메서드
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/example/nationalfitnessapp/domain/User.java
+++ b/src/main/java/com/example/nationalfitnessapp/domain/User.java
@@ -1,16 +1,20 @@
 package com.example.nationalfitnessapp.domain;
 import jakarta.persistence.*;
 
-import lombok.NoArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;  // 모든 필드를 파라미터로 가지는 생성자 자동 생성
+import lombok.NoArgsConstructor;  // 파라미터가 없는 기본 생성자 자동 생성
+import lombok.Getter; // 필드의 Get 메서드를 자동 생성한다.
+import lombok.Setter;  // 필드의 Set 메서드를 자동 생성한다.
+import lombok.Builder;  // 필요한 값만, 순서에 상관없이, 객체 생성이 가능하다. (예: User user = User.builder().loginId("newuser").passwordHash("hash"))
 
 import java.time.LocalDateTime;
 @Entity
 @Table(name = "User")
-@Getter  // generate field's get methods automatically
-@Setter  // generate field's set methods automatically
-@NoArgsConstructor  // No argument default constructor generate automatically
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)  // Auto_Increment
@@ -28,19 +32,11 @@ public class User {
     @Column(unique = true, nullable = false, length=100)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public User(String loginId, String passwordHash, String nickname, String email){
-        this.loginId = loginId;
-        this.passwordHash = passwordHash;
-        this.nickname = nickname;
-        this.email = email;
-    }
-
-    @PrePersist  // Call this method when Entity generate
+    @PrePersist  // 엔티티가 생성될 때 이 메서드를 호출한다.
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
 }
-

--- a/src/main/java/com/example/nationalfitnessapp/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/nationalfitnessapp/dto/LoginRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.nationalfitnessapp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequestDto {
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/com/example/nationalfitnessapp/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/nationalfitnessapp/dto/SignupRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.nationalfitnessapp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+    private String loginId;
+    private String password;
+    private String nickname;
+    private String email;
+}

--- a/src/main/java/com/example/nationalfitnessapp/dto/TokenDto.java
+++ b/src/main/java/com/example/nationalfitnessapp/dto/TokenDto.java
@@ -1,0 +1,12 @@
+package com.example.nationalfitnessapp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+    private String grantType;  // "Bearer
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/nationalfitnessapp/dto/TokenRequestDto.java
+++ b/src/main/java/com/example/nationalfitnessapp/dto/TokenRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.nationalfitnessapp.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TokenRequestDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/nationalfitnessapp/repository/UserRepository.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/UserRepository.java
@@ -18,4 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // loginId를 기준으로 DB에서 사용자 정보를 가져오는 기능 (해당하는 사용자가 없을 수도 있으므로 Optional로 감싸서 반환
     Optional<User> findByLoginId(String loginId);
+
+    // Refresh Token으로 사용자를 찾기 위한 메서드
+    Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/example/nationalfitnessapp/repository/UserRepository.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/UserRepository.java
@@ -1,0 +1,21 @@
+package com.example.nationalfitnessapp.repository;
+
+import com.example.nationalfitnessapp.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 이미 사용중인 loginId인지 확인하는 메서드
+    boolean existsByLoginId(String loginId);
+
+    // 이미 등록에 사용되었던 email인지 확인하는 메서드
+    boolean existsByEmail(String email);
+
+    // 이미 사용중인 닉네임인지 확인하는 메서드
+    boolean existsByNickname(String nickname);
+
+    // loginId를 기준으로 DB에서 사용자 정보를 가져오는 기능 (해당하는 사용자가 없을 수도 있으므로 Optional로 감싸서 반환
+    Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/example/nationalfitnessapp/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/nationalfitnessapp/security/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.example.nationalfitnessapp.security;
+
+import com.example.nationalfitnessapp.dto.TokenDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessTokenValidityInSeconds;
+    private final long refreshTokenValidityInSeconds;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidity,
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidity) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidityInSeconds = accessTokenValidity * 1000;
+        this.refreshTokenValidityInSeconds = refreshTokenValidity * 1000;
+    }
+
+    // [수정] role 파라미터 삭제
+    public TokenDto createTokens(String loginId) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiresIn = new Date(now + accessTokenValidityInSeconds);
+        Date refreshTokenExpiresIn = new Date(now + refreshTokenValidityInSeconds);
+
+        String accessToken = Jwts.builder()
+                .setSubject(loginId)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(refreshTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public String getLoginId(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.info("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // 만료된 토큰에서도 Claim을 꺼내기 위한 메서드
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch(ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/example/nationalfitnessapp/service/UserService.java
+++ b/src/main/java/com/example/nationalfitnessapp/service/UserService.java
@@ -1,0 +1,41 @@
+package com.example.nationalfitnessapp.service;
+
+import com.example.nationalfitnessapp.repository.UserRepository;
+import com.example.nationalfitnessapp.domain.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 회원 가입 메서드 (성공하면 서버에 올리고 실패하면 실패 메시지 전송)
+     * @param loginId 사용자가 선택한 로그인 ID
+     * @param password 사용자가 선택한 패스워드 ID
+     * @param nickname 사용자가 선택한 닉네임
+     * @param email 사용자가 선택한 닉네임
+     * @return 성공 메시지 반환
+     * */
+
+    /**
+     * 로그인 메서드 (성공하면 토큰을 부여하고 실패하면 실패 메시지 전송)
+     * @param loginId 사용자가 입력한 로그인 ID
+     * @param password 사용자가 입력한 패스워드
+     * @return 토큰과 함께 성공 메시지 반환
+     * */
+
+    /**
+     * 토큰 재설정 메서드
+     * @param token 클라이언트가 재설정을 요구하며 보낸 Refresh 토큰
+     * @return 재설정된 Refresh Token 과 Access Token 반환
+     * */
+
+}

--- a/src/main/java/com/example/nationalfitnessapp/service/UserService.java
+++ b/src/main/java/com/example/nationalfitnessapp/service/UserService.java
@@ -1,10 +1,12 @@
 package com.example.nationalfitnessapp.service;
 
-import com.example.nationalfitnessapp.repository.UserRepository;
 import com.example.nationalfitnessapp.domain.User;
-
+import com.example.nationalfitnessapp.dto.TokenDto;
+import com.example.nationalfitnessapp.repository.UserRepository;
+import com.example.nationalfitnessapp.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /**
      * 회원 가입 메서드 (성공하면 서버에 올리고 실패하면 실패 메시지 전송)
@@ -24,6 +28,33 @@ public class UserService {
      * @param email 사용자가 선택한 닉네임
      * @return 성공 메시지 반환
      * */
+    @Transactional
+    public User signUp(String loginId, String password, String nickname, String email){
+        // 1. 중복 확인
+        if (userRepository.existsByLoginId(loginId)){
+            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+        }
+        if (userRepository.existsByNickname(nickname)){
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+        if (userRepository.existsByEmail(email)){
+            throw new IllegalArgumentException("이미 등록된 이메일입니다.");
+        }
+
+        // 2. 비밀번호 암호화
+        String hashedPassword = passwordEncoder.encode(password);
+
+        // 3. 사용자 생성 및 저장
+        User newUser = User.builder()
+                .loginId(loginId)
+                .passwordHash(hashedPassword)
+                .nickname(nickname)
+                .email(email)
+                .build();
+
+        // 4. UserRepository를 이용해 DB에 새로운 유저 정보 저장하면서 User 객체 리턴
+        return userRepository.save(newUser);
+    }
 
     /**
      * 로그인 메서드 (성공하면 토큰을 부여하고 실패하면 실패 메시지 전송)
@@ -31,11 +62,58 @@ public class UserService {
      * @param password 사용자가 입력한 패스워드
      * @return 토큰과 함께 성공 메시지 반환
      * */
+    @Transactional
+    public TokenDto login(String loginId, String password){
+        // 1. 아이디로 사용자 조회
+        User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new IllegalArgumentException("없는 아이디이거나 비밀번호가 틀렸습니다."));
+
+        // 2. 비밀번호 확인
+        if (!passwordEncoder.matches(password, user.getPasswordHash())){
+            throw new IllegalArgumentException("없는 아이디이거나 비밀번호가 틀렸습니다.");
+        }
+
+        // 3. JWT 토큰 생성
+        TokenDto tokenDto = jwtTokenProvider.createTokens(loginId);
+
+        // 4. Refresh 토큰을 사용자 정보에 업데이트
+        user.updateRefreshToken(tokenDto.getRefreshToken());
+        userRepository.save(user);  // 변경된 사용자 정보를 DB에 저장
+
+        return tokenDto;
+    }
 
     /**
      * 토큰 재설정 메서드
-     * @param token 클라이언트가 재설정을 요구하며 보낸 Refresh 토큰
+     * @param accessToken 클라이언트가 재설정을 요구하며 보낸 Access 토큰
+     * @param refreshToken 클라이언트가 재설정을 요구하며 보낸 Refresh 토큰
      * @return 재설정된 Refresh Token 과 Access Token 반환
      * */
+    @Transactional
+    public TokenDto refreshToken(String accessToken, String refreshToken) {
 
+        // 1. Refresh Token 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token 입니다.");
+        }
+
+        // 2. Access Token에서 사용자 정보(loginId) 가져오기 (만료되었어도 정보 추출은 가능)
+        String loginId = jwtTokenProvider.parseClaims(accessToken).getSubject();
+        User user = userRepository.findByLoginId(loginId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 3. DB에 저장된 Refresh Token과 클라이언트가 보낸 Refresh Token이 일치하는지 확인
+        if (!refreshToken.equals(user.getRefreshToken())){
+            // 일치하지 않으면, 토큰이 탈취되었을 가능성이 있으므로 로그아웃 처리
+            // 보안을 위해 DB의 Refresh Token을 null로 만들어 해당 토큰을 더 이상 못쓰게 처리
+            user.updateRefreshToken(null);
+            throw new IllegalArgumentException("토큰 정보가 일치하지 않습니다.");
+        }
+
+        // 4. 새로운 토큰 생성
+        TokenDto newTokenDto = jwtTokenProvider.createTokens(loginId);
+
+        // 5. DB에 새로운 Refresh 토큰으로 업데이트
+        user.updateRefreshToken(newTokenDto.getRefreshToken());
+
+        return newTokenDto;
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
### JWT(JSON Web Token)를 사용한 사용자 인증 시스템의 핵심 기능 구현
**회원가입 API 구현**
- POST /api/auth/signup
- 사용자 정보(ID, 비밀번호, 닉네임, 이메일)를 받아 계정 생성
- 비밀번호는 BCrypt로 해싱하여 데이터베이스에 저장

**로그인 API 구현**
- POST /api/auth/login
- 로그인 성공 시, Access Token과 Refresh Token 발급
- 발급된 Refresh Token은 DB의 사용자 정보에 저장하여 토큰 재발급에 사용

**토큰 재발급 API 구현**
- POST /api/auth/refresh
- 기존 토큰을 받아 유효성을 검증한 후 새로운 Access/Refresh Token 발급

**Spring Security 설정 추가**
- SecurityConfig를 통해 인증/인가 로직 설정
- /api/auth/** 등 공개 API를 제외한 모든 요청은 인증을 요구하도록 설정
- JWT 기반 인증을 위해 SessionCreationPolicy.STATELESS 및 csrf.disable() 설정 적용
**User 엔티티 수정**
- Refresh Token 저장을 위해 refreshToken 필드 추가