### PR TITLE
feat(exercise): ID 목록으로 운동 영상 다건 조회 API 구현

### DIFF
--- a/src/main/java/com/example/nationalfitnessapp/controller/ExerciseController.java
+++ b/src/main/java/com/example/nationalfitnessapp/controller/ExerciseController.java
@@ -1,8 +1,10 @@
 package com.example.nationalfitnessapp.controller;
 
 import com.example.nationalfitnessapp.domain.Exercise;
+import com.example.nationalfitnessapp.dto.ExerciseResponseDto;
 import com.example.nationalfitnessapp.service.ExerciseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,5 +70,18 @@ public class ExerciseController {
         // 이름순으로 정렬
         Pageable pageable = PageRequest.of(page, size, Sort.by("title").ascending());
         return exerciseService.findExercisesByMuscles(muscles, pageable);
+    }
+
+    /**
+     * 여러 개의 ID로 운동 영상 목록을 조회하는 API
+     * @param ids 쉼표로 구분된 exerciseId 목록(예: 1,2,3)
+     * @return ExerciseResponseDto 객체 리스트
+     */
+    @GetMapping("/by-ids")
+    public ResponseEntity<List<ExerciseResponseDto>> getExercisesByIds(
+            @RequestParam("id") List<Long> ids
+    ) {
+        List<ExerciseResponseDto> exercises = exerciseService.findExercisesByIds(ids);
+        return ResponseEntity.ok(exercises);
     }
 }

--- a/src/main/java/com/example/nationalfitnessapp/repository/ExerciseRepository.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/ExerciseRepository.java
@@ -4,8 +4,13 @@ import com.example.nationalfitnessapp.domain.Exercise;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;  // 복잡한 동적 검색 조건을 실제로 실행시켜주는 실행기의 역할을 한다.
 
+import java.util.List;
+
 public interface ExerciseRepository extends JpaRepository<Exercise, Long>, JpaSpecificationExecutor<Exercise>{
 
     // videoUrl을 기준으로 데이터가 이미 존재하는지 확인하는 메서드
     boolean existsByVideoUrl(String videoUrl);
+
+    // ID 목록을 받아 (IN 쿼리) 엔티티 리스트를 반환하는 메서드
+    List<Exercise> findAllByExerciseIdIn(List<Long> exerciseIds);
 }

--- a/src/main/java/com/example/nationalfitnessapp/service/ExerciseService.java
+++ b/src/main/java/com/example/nationalfitnessapp/service/ExerciseService.java
@@ -1,6 +1,7 @@
 package com.example.nationalfitnessapp.service;
 
 import com.example.nationalfitnessapp.domain.Exercise;
+import com.example.nationalfitnessapp.dto.ExerciseResponseDto;
 import com.example.nationalfitnessapp.repository.ExerciseSpecification;
 import com.example.nationalfitnessapp.dto.ExerciseApiResponse;
 import com.example.nationalfitnessapp.dto.ExerciseDto;
@@ -17,7 +18,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -46,91 +49,6 @@ public class ExerciseService {
     private String viewAllUrl;
     @Value("${exercise.api.baseUrl.trainingVideo}")
     private String trainingVideoUrl;
-
-    /**
-     * 모든 운동 영상 API를 호출하여 DB에 저장하는 작업을 총괄하는 메서드
-     * 데이터를 DB에 저장 완료했으니 더 이상 사용하지 않는다.
-     */
-//    @Transactional
-//    public void fetchAndSaveAllExercises() {
-//        log.info("모든 운동 영상 데이터 저장을 시작합니다.");
-//
-//        int totalSavedCount = 0;
-//        // 각 API를 순차적으로 호출하여 데이터를 가져오고, 저장된 개수를 누적
-//        totalSavedCount += fetchAndSaveFromApi(guideUrl, "운동 가이드");
-//        totalSavedCount += fetchAndSaveFromApi(fitnessTestUrl, "체력 인증");
-//        totalSavedCount += fetchAndSaveFromApi(muscleTrainingUrl, "근력 운동");
-//        totalSavedCount += fetchAndSaveFromApi(standardFitnessUrl, "표준 운동");
-//        totalSavedCount += fetchAndSaveFromApi(weeklyProgramUrl, "주간 프로그램");
-//        totalSavedCount += fetchAndSaveFromApi(viewAllUrl, "전체 목록");
-//        totalSavedCount += fetchAndSaveFromApi(trainingVideoUrl, "일반 운동 영상");
-//
-//        log.info("모든 운동 영상 데이터 저장을 완료했습니다. 총 저장된 데이터 수: {}", totalSavedCount);
-//    }
-//
-//    /**
-//     * 데이터 다운로드 완료
-//     * 특정 API의 전체 데이터를 페이징하여 가져오는 공통 헬퍼 메서드
-//     * @param baseUrl 호출할 API의 Base URL
-//     * @param apiName 로그에 표시할 API 이름
-//     * @return 새로 저장된 데이터의 수
-//     */
-//    private int fetchAndSaveFromApi(String baseUrl, String apiName) {
-//        log.info(">>> [{}] API 데이터 저장을 시작합니다.", apiName);
-//
-//        // 1. 첫 페이지를 호출하여 totalCount 가져오기
-//        ExerciseApiResponse firstResponse = callApi(baseUrl, 1, 10);
-//        if (firstResponse == null || firstResponse.getBody() == null) {
-//            log.warn("[{}] API로부터 유효한 첫 응답을 받지 못했습니다. 이 API는 건너뜁니다.", apiName);
-//            return 0;
-//        }
-//
-//        // 🚨 중요: ExerciseApiBody.java에 totalCount 필드가 있어야 합니다.
-//        // final int TOTAL_COUNT = firstResponse.getBody().getTotalCount();
-//        // 우선은 임시로 매우 큰 값으로 설정합니다.
-//        final int TOTAL_COUNT = firstResponse.getBody().getTotalCount(); // 나중에 DTO에 totalCount 필드를 추가하고 위 코드로 교체하세요.
-//
-//        if (TOTAL_COUNT == 0) {
-//            log.info("[{}] API에 데이터가 없습니다.", apiName);
-//            return 0;
-//        }
-//
-//        final int ROWS_PER_PAGE = 1000; // 한 번에 1000개씩 요청하여 효율 증대
-//        int totalPages = (TOTAL_COUNT + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE;
-//        int totalSavedCountInApi = 0;
-//        log.info("[{}] 총 데이터 약: {}, 페이지당 데이터: {}, 총 페이지: {}", apiName, TOTAL_COUNT, ROWS_PER_PAGE, totalPages);
-//
-//        // 2. 전체 페이지 순회
-//        for (int page = 1; page <= totalPages; page++) {
-//            log.info("[{}] 페이지 {}/{} 처리 중...", apiName, page, totalPages);
-//            ExerciseApiResponse apiResponse = callApi(baseUrl, page, ROWS_PER_PAGE);
-//
-//            if (apiResponse == null || apiResponse.getBody() == null || apiResponse.getBody().getItems() == null || apiResponse.getBody().getItems().getExerciseList() == null) {
-//                log.warn("[{}] 페이지 {}에서 유효한 데이터를 받아오지 못했습니다. 다음 페이지로 넘어갑니다.", apiName, page);
-//                continue;
-//            }
-//            List<ExerciseDto> dtoList = apiResponse.getBody().getItems().getExerciseList();
-//
-//            if (dtoList.isEmpty()) {
-//                log.info("[{}] 페이지 {}에 더 이상 데이터가 없어 이 API의 처리를 중단합니다.", apiName, page);
-//                break; // 데이터가 없으면 루프 중단
-//            }
-//
-//            int savedCountInPage = 0;
-//            for (ExerciseDto dto : dtoList) {
-//                Exercise exercise = dto.toEntity();
-//                String fullUrl = exercise.getVideoUrl();
-//
-//                if (fullUrl != null && !exerciseRepository.existsByVideoUrl(fullUrl)) {
-//                    exerciseRepository.save(exercise);
-//                    savedCountInPage++;
-//                }
-//            }
-//            totalSavedCountInApi += savedCountInPage;
-//        }
-//        log.info("<<< [{}] API에서 총 {}개의 새로운 영상을 저장했습니다.", apiName, totalSavedCountInApi);
-//        return totalSavedCountInApi;
-//    }
 
     /*
      * WebClient를 사용해 실제 API를 호출하는 공통 메서드
@@ -236,4 +154,110 @@ public class ExerciseService {
 
         return exerciseRepository.findAll(spec, pageable);
     }
+
+    /**
+     * ID 목록으로 여러 개의 운동 영상을 조회하는 메서드
+     * @param exerciseIds 조회할 ID 리스트
+     * @return ExerciseResponseDto 리스트
+     */
+    public List<ExerciseResponseDto> findExercisesByIds(List<Long> exerciseIds) {
+        if (exerciseIds == null || exerciseIds.isEmpty()) {
+            return Collections.emptyList();  // 빈 리스트 반환
+        }
+
+        // 1. Repository에 새로 추가한 메서드로 Entity 리스트를 한 번에 조회
+        List<Exercise> exercises = exerciseRepository.findAllByExerciseIdIn(exerciseIds);
+
+        // 2. Entity 리스트를 DTO 리스트로 변환하여 반환
+        return exercises.stream()
+                .map(ExerciseResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
+
+//    /**
+//     * 모든 운동 영상 API를 호출하여 DB에 저장하는 작업을 총괄하는 메서드
+//     * 데이터를 DB에 저장 완료했으니 더 이상 사용하지 않는다.
+//     */
+//    @Transactional
+//    public void fetchAndSaveAllExercises() {
+//        log.info("모든 운동 영상 데이터 저장을 시작합니다.");
+//
+//        int totalSavedCount = 0;
+//        // 각 API를 순차적으로 호출하여 데이터를 가져오고, 저장된 개수를 누적
+//        totalSavedCount += fetchAndSaveFromApi(guideUrl, "운동 가이드");
+//        totalSavedCount += fetchAndSaveFromApi(fitnessTestUrl, "체력 인증");
+//        totalSavedCount += fetchAndSaveFromApi(muscleTrainingUrl, "근력 운동");
+//        totalSavedCount += fetchAndSaveFromApi(standardFitnessUrl, "표준 운동");
+//        totalSavedCount += fetchAndSaveFromApi(weeklyProgramUrl, "주간 프로그램");
+//        totalSavedCount += fetchAndSaveFromApi(viewAllUrl, "전체 목록");
+//        totalSavedCount += fetchAndSaveFromApi(trainingVideoUrl, "일반 운동 영상");
+//
+//        log.info("모든 운동 영상 데이터 저장을 완료했습니다. 총 저장된 데이터 수: {}", totalSavedCount);
+//    }
+//
+//    /**
+//     * 데이터 다운로드 완료
+//     * 특정 API의 전체 데이터를 페이징하여 가져오는 공통 헬퍼 메서드
+//     * @param baseUrl 호출할 API의 Base URL
+//     * @param apiName 로그에 표시할 API 이름
+//     * @return 새로 저장된 데이터의 수
+//     */
+//    private int fetchAndSaveFromApi(String baseUrl, String apiName) {
+//        log.info(">>> [{}] API 데이터 저장을 시작합니다.", apiName);
+//
+//        // 1. 첫 페이지를 호출하여 totalCount 가져오기
+//        ExerciseApiResponse firstResponse = callApi(baseUrl, 1, 10);
+//        if (firstResponse == null || firstResponse.getBody() == null) {
+//            log.warn("[{}] API로부터 유효한 첫 응답을 받지 못했습니다. 이 API는 건너뜁니다.", apiName);
+//            return 0;
+//        }
+//
+//        // 🚨 중요: ExerciseApiBody.java에 totalCount 필드가 있어야 합니다.
+//        // final int TOTAL_COUNT = firstResponse.getBody().getTotalCount();
+//        // 우선은 임시로 매우 큰 값으로 설정합니다.
+//        final int TOTAL_COUNT = firstResponse.getBody().getTotalCount(); // 나중에 DTO에 totalCount 필드를 추가하고 위 코드로 교체하세요.
+//
+//        if (TOTAL_COUNT == 0) {
+//            log.info("[{}] API에 데이터가 없습니다.", apiName);
+//            return 0;
+//        }
+//
+//        final int ROWS_PER_PAGE = 1000; // 한 번에 1000개씩 요청하여 효율 증대
+//        int totalPages = (TOTAL_COUNT + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE;
+//        int totalSavedCountInApi = 0;
+//        log.info("[{}] 총 데이터 약: {}, 페이지당 데이터: {}, 총 페이지: {}", apiName, TOTAL_COUNT, ROWS_PER_PAGE, totalPages);
+//
+//        // 2. 전체 페이지 순회
+//        for (int page = 1; page <= totalPages; page++) {
+//            log.info("[{}] 페이지 {}/{} 처리 중...", apiName, page, totalPages);
+//            ExerciseApiResponse apiResponse = callApi(baseUrl, page, ROWS_PER_PAGE);
+//
+//            if (apiResponse == null || apiResponse.getBody() == null || apiResponse.getBody().getItems() == null || apiResponse.getBody().getItems().getExerciseList() == null) {
+//                log.warn("[{}] 페이지 {}에서 유효한 데이터를 받아오지 못했습니다. 다음 페이지로 넘어갑니다.", apiName, page);
+//                continue;
+//            }
+//            List<ExerciseDto> dtoList = apiResponse.getBody().getItems().getExerciseList();
+//
+//            if (dtoList.isEmpty()) {
+//                log.info("[{}] 페이지 {}에 더 이상 데이터가 없어 이 API의 처리를 중단합니다.", apiName, page);
+//                break; // 데이터가 없으면 루프 중단
+//            }
+//
+//            int savedCountInPage = 0;
+//            for (ExerciseDto dto : dtoList) {
+//                Exercise exercise = dto.toEntity();
+//                String fullUrl = exercise.getVideoUrl();
+//
+//                if (fullUrl != null && !exerciseRepository.existsByVideoUrl(fullUrl)) {
+//                    exerciseRepository.save(exercise);
+//                    savedCountInPage++;
+//                }
+//            }
+//            totalSavedCountInApi += savedCountInPage;
+//        }
+//        log.info("<<< [{}] API에서 총 {}개의 새로운 영상을 저장했습니다.", apiName, totalSavedCountInApi);
+//        return totalSavedCountInApi;
+//    }
 }


### PR DESCRIPTION
### 주요 변경 사항 🛠️
**ExerciseRepository**

- findAllByExerciseIdIn(List<Long> ids) 메서드를 추가하여, JPA가 자동으로 WHERE id IN (...) 쿼리를 생성하도록 했습니다.

**ExerciseService**

- findExercisesByIds 메서드를 추가했습니다.

- 조회된 엔티티 리스트를 ExerciseResponseDto 리스트로 변환하여 반환합니다.

**ExerciseController**

- GET /api/exercises/by-ids 엔드포인트를 추가했습니다.

- ids 파라미터로 쉼표로 구분된 ID 목록(예: 1,2,3)을 받아 처리합니다.