### PR TITLE
feat(search): 운동 키워드 검색 시 title과 standard_title을 OR로 동시 검색

### DIFF
--- a/src/main/java/com/example/nationalfitnessapp/repository/ExerciseSpecification.java
+++ b/src/main/java/com/example/nationalfitnessapp/repository/ExerciseSpecification.java
@@ -20,6 +20,11 @@ public class ExerciseSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + keyword + "%");
     }
 
+    // like 조건으로 standard_title 제목 검색
+    public static Specification<Exercise> likeStandardTitle(String keyword) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("standardTitle"), "%" + keyword + "%");
+    }
+
     // 질환치료를 검색할 때 description 에서 like 검색을 해야 한다.
     public static Specification<Exercise> likeDescriptionForDisease(String disease) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("description"), "%" + disease + "%");

--- a/src/main/java/com/example/nationalfitnessapp/service/ExerciseService.java
+++ b/src/main/java/com/example/nationalfitnessapp/service/ExerciseService.java
@@ -104,7 +104,8 @@ public class ExerciseService {
 
         // 2. 각 파라미터가 존재하면, AND 조건으로 레고 블록을 조립
         if (keyword != null && !keyword.isEmpty()) {
-            spec = spec.and(ExerciseSpecification.likeTitle(keyword));
+            Specification<Exercise> keywordSpec = ExerciseSpecification.likeTitle(keyword).or(ExerciseSpecification.likeStandardTitle(keyword));
+            spec = spec.and(keywordSpec);
         }
         if (targetGroup != null && !targetGroup.isEmpty()) {
             // [수정] '공통' 로직이 포함된 filterByTargetGroup 사용


### PR DESCRIPTION
### 주요 변경 사항 🛠️
**ExerciseSpecification.java**

- standardTitle 필드를 LIKE 검색하는 likeStandardTitle 메서드를 새로 추가했습니다.

**ExerciseService.java (findAll 메서드)**

- keyword 파라미터가 존재할 경우, likeTitle와 likeStandardTitle 두 Specification을 OR 조건으로 조합하여 검색하도록 로직을 수정했습니다.